### PR TITLE
Fix build errors

### DIFF
--- a/boron/Makefile
+++ b/boron/Makefile
@@ -191,7 +191,7 @@ $(KERNEL): $(SYMBOLS)
 	
 $(SYMBOLS): $(KERNEL2)
 	@echo "[NM]\tDumping and compiling symbols"
-	@nm -P $(KERNEL2) | $(SCRIPTS_DIR)/generate_symbols_nasm.py $(TARGETL) > $(BUILD_DIR)/_symtab.$(TARGETL).asm
+	@nm -P $(KERNEL2) | python3 $(SCRIPTS_DIR)/generate_symbols_nasm.py $(TARGETL) > $(BUILD_DIR)/_symtab.$(TARGETL).asm
 	@$(BASM) $(NASMFLAGS) $(BUILD_DIR)/_symtab.$(TARGETL).asm -o $(BUILD_DIR)/_symtab.$(TARGETL).o
 	
 $(KERNEL2): $(KERNEL_PARTIAL)
@@ -212,7 +212,7 @@ $(KERNEL): $(SYMBOLS)
 	
 $(SYMBOLS): $(KERNEL2)
 	@echo "[NM]\tDumping and compiling symbols"
-	@nm -P $(KERNEL2) | $(SCRIPTS_DIR)/generate_symbols_gas.py $(TARGETL) > $(BUILD_DIR)/_symtab.$(TARGETL).S
+	@nm -P $(KERNEL2) | python3 $(SCRIPTS_DIR)/generate_symbols_gas.py $(TARGETL) > $(BUILD_DIR)/_symtab.$(TARGETL).S
 	@$(BCC) $(CPPFLAGS) $(CFLAGS) -c $(BUILD_DIR)/_symtab.$(TARGETL).S -o $(BUILD_DIR)/_symtab.$(TARGETL).o
 	
 $(KERNEL2): $(KERNEL_PARTIAL)

--- a/boron/source/ps/shutdown.c
+++ b/boron/source/ps/shutdown.c
@@ -28,6 +28,7 @@ Author:
 ***/
 #include "psp.h"
 #include <cc.h>
+#include <hal.h>
 #include <mm.h>
 
 static KTHREAD PsShutDownWorkerThread;


### PR DESCRIPTION
This PR fixes two build errors, the first one being this:
```
source/ps/shutdown.c: In function ‘PsShutDownWorker’:
source/ps/shutdown.c:74:9: error: implicit declaration of function ‘HalBeginShutdown’ [-Wimplicit-function-declaration]
   74 |         HalBeginShutdown();
      |         ^~~~~~~~~~~~~~~~
[CC]\tCompiling source/rtl/status.c
source/ps/shutdown.c:107:9: error: implicit declaration of function ‘HalPerformPoweroff’ [-Wimplicit-function-declaration]
  107 |         HalPerformPoweroff(false);
      |         ^~~~~~~~~~~~~~~~~~
source/ps/shutdown.c:108:1: warning: ‘noreturn’ function does return
  108 | }
      | ^
```
And the second one being this:
```
/bin/sh: line 1: scripts/generate_symbols_nasm.py: Permission denied
make[1]: *** [Makefile:194: build/_symtab.amd64.o] Error 126
```